### PR TITLE
Casing Removal

### DIFF
--- a/spaceandtimesdk.py
+++ b/spaceandtimesdk.py
@@ -581,7 +581,7 @@ class SpaceAndTimeSDK:
                 payload = {
                 "biscuits":biscuit_tokens,
                 "resourceId":resource_id.upper(),
-                "sqlText":sql_text.upper(),
+                "sqlText":sql_text
             }
 
             headers = {

--- a/spaceandtimesdk.py
+++ b/spaceandtimesdk.py
@@ -505,7 +505,7 @@ class SpaceAndTimeSDK:
 
             payload = {
                 "biscuits":biscuit_tokens,
-                "sqlText":sql_text.upper()
+                "sqlText":sql_text
             }
 
             headers = {
@@ -538,7 +538,7 @@ class SpaceAndTimeSDK:
             payload = {
                 "biscuits":biscuit_tokens,
                 "resourceId":resource_id.upper(),
-                "sqlText":sql_text.upper(),
+                "sqlText":sql_text
             }
 
             headers = {
@@ -574,7 +574,7 @@ class SpaceAndTimeSDK:
                 payload = {
                 "biscuits":biscuit_tokens,
                 "resourceId":resource_id.upper(),
-                "sqlText":sql_text.upper(),
+                "sqlText":sql_text,
                 "rowCount":row_count
             }
             else:


### PR DESCRIPTION
Removed the conversion of the SQL queries written by the user to upper case.
Previously this led to the conversion of the User's data in DML to get converted to upper casing.

I'm letting the conversion stay in ``Create Schema`` and the ``CREATE TABLE MY_NAMESPACE.MY_TABLE( id  int, name  varchar, PRIMARY KEY (id))`` part of the Table creation function though as it is required.