### PR TITLE
Fix join subscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ publish.sh
 venv_*
 tests/backup_biscuits/
 tests/latest_test_log.txt
+tests/user_saves
 
 
 # C extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spaceandtime"
-version = "1.1.28"
+version = "1.1.29"
 description = "SDK for Space and Time verifiable database"
 authors = [{ name = "Stephen Hilton", email = "stephen.hilton@spaceandtime.io" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spaceandtime"
-version = "1.1.24"
+version = "1.1.28"
 description = "SDK for Space and Time verifiable database"
 authors = [{ name = "Stephen Hilton", email = "stephen.hilton@spaceandtime.io" }]
 readme = "README.md"

--- a/src/spaceandtime/apiversions.json
+++ b/src/spaceandtime/apiversions.json
@@ -29,10 +29,9 @@
     "discover/blockchains/{chainId}/schemas": "v2",                         
     "discover/blockchains/{chainId}/meta":    "v2",
     "subscription":                           "v1",
-    "subscription/users":                     "v1",
     "subscription/invite":                    "v1",
     "subscription/invite/{joinCode}":         "v1",
-    "/subscription/leave":                    "v1",
+    "subscription/leave":                    "v1",
     "subscription/remove/{userId}":           "v1",   
     "subscription/setrole/{userId}":          "v1",
     "subscription/users":                     "v1"

--- a/src/spaceandtime/apiversions.json
+++ b/src/spaceandtime/apiversions.json
@@ -31,5 +31,9 @@
     "subscription":                           "v1",
     "subscription/users":                     "v1",
     "subscription/invite":                    "v1",
-    "subscription/invite/{joinCode}":         "v1"
+    "subscription/invite/{joinCode}":         "v1",
+    "/subscription/leave":                    "v1",
+    "subscription/remove/{userId}":           "v1",   
+    "subscription/setrole/{userId}":          "v1",
+    "subscription/users":                     "v1"
 }

--- a/src/spaceandtime/sxtbaseapi.py
+++ b/src/spaceandtime/sxtbaseapi.py
@@ -262,7 +262,7 @@ class SXTBaseAPI():
         """
         dataparms = {"userId": user_id}
         if prefix: dataparms["prefix"] = prefix
-        if joincode: dataparms[joincode] = joincode
+        if joincode: dataparms["joincode"] = joincode
         success, rtn = self.call_api(endpoint = 'auth/code', auth_header = False, data_parms = dataparms)
         return success, rtn if success else [rtn]
 
@@ -349,7 +349,7 @@ class SXTBaseAPI():
             bool: Success flag (True/False) indicating the api call worked as expected.
             object: Response information from the Space and Time network, as list or dict(json). 
         """
-        success, rtn = self.call_api(f'auth/idexists/{user_id}', False, SXTApiCallTypes.GET)
+        success, rtn = self.call_api('auth/idexists/{id}', False, SXTApiCallTypes.GET, path_parms={'id':user_id})
         return success, rtn if success else [rtn]
     
     
@@ -692,9 +692,64 @@ class SXTBaseAPI():
         endpoint = 'subscription/invite/{joinCode}'
         version = 'v2' if endpoint not in list(self.versions.keys()) else self.versions[endpoint] 
         success, rtn = self.call_api(endpoint=endpoint, auth_header=True, request_type=SXTApiCallTypes.POST,
-                                     path_parms= {'{joinCode}': joincode} )
+                                     path_parms= {'joinCode': joincode} )
         return success, (rtn if success else [rtn]) 
 
+
+    def subscription_leave(self):
+        """--------------------
+        Allows the authenticated user to leave their subscription.
+
+        Calls and returns data from API: subscription/leave.  
+
+        Args: 
+            None
+        
+        Returns:
+            bool: Success flag (True/False) indicating the api call worked as expected.
+            object: Response information from the Space and Time network, as list or dict(json). 
+        """
+        endpoint = 'subscription/leave'
+        version = 'v2' if endpoint not in list(self.versions.keys()) else self.versions[endpoint] 
+        success, rtn = self.call_api(endpoint=endpoint, auth_header=True, request_type=SXTApiCallTypes.POST )
+        return success, (rtn if success else [rtn])
+
+
+    def subscription_get_users(self) -> tuple[bool, dict]:
+        """
+        Returns a list of all users in the current subscription.
+
+        Args:
+            None
+
+        Returns:
+            bool: Success flag (True/False) indicating the api call worked as expected.
+            object: Dictionary of User_IDs and User Permission level in the subscription, or error as json.
+        """
+        endpoint = 'subscription/users'
+        version = 'v2' if endpoint not in list(self.versions.keys()) else self.versions[endpoint] 
+        success, rtn = self.call_api(endpoint=endpoint, auth_header=True, request_type=SXTApiCallTypes.GET )
+        if success: rtn = rtn['roleMap']
+        return success, rtn
+        
+
+    def subscription_remove(self, User_ID_to_Remove:str) -> tuple[bool, dict]:
+        """
+        Removes another user from the current user's subscription.  Current user must have more authority than the targeted user to remove.
+
+        Args: 
+            User_ID_to_Remove (str): ID of the user to remove from the current user's subscription.
+
+        Returns:
+            bool: Success flag (True/False) indicating the api call worked as expected.
+            object: Response information from the Space and Time network, as list or dict(json).
+        """
+        endpoint = 'subscription/remove/{userId}'
+        version = 'v2' if endpoint not in list(self.versions.keys()) else self.versions[endpoint] 
+        success, rtn = self.call_api(endpoint=endpoint, auth_header=True, request_type=SXTApiCallTypes.POST,
+                                     path_parms= {'userId': User_ID_to_Remove} )
+        return success, rtn
+        
 
 
 if __name__ == '__main__':

--- a/src/spaceandtime/sxtresource.py
+++ b/src/spaceandtime/sxtresource.py
@@ -205,10 +205,12 @@ class SXTResource():
         """Returns True of the resource appears on the Space and Time network, or False if it is missing.  
         Returns None if a connection cannot be established or encountered an error."""
         if self.user.access_expired: self.user.authenticate()
+        # __existfunc__ is defined by the interhiriting child class (table, view, etc.) which has the same signature, but called here
         success, resources = self.__existfunc__(schema=self.schema)
         if success:
             apiname = 'table' if self.resource_type.name.lower() == 'table' else 'view'
-            does_exist = f"{self.schema}.{self.name}".upper() in [ f"{r['schema']}.{r[apiname]}" for r in resources]
+
+            does_exist = str(self.name).upper() in [ r[apiname] for r in resources]
             self.logger.debug(f'testing whether {self.resource_name} exists:  {str(does_exist)}')
             return does_exist 
         else:

--- a/tests/test_create_users_and_join_sub.py
+++ b/tests/test_create_users_and_join_sub.py
@@ -1,0 +1,66 @@
+import os, sys, pytest, pandas, random
+from pathlib import Path
+
+# load local copy of libraries
+sys.path.append(str( Path(Path(__file__).parents[1] / 'src').resolve() ))
+from spaceandtime.spaceandtime import SXTUser
+
+
+def test_remove_all_users_from_test_subscription():
+    # login with admin
+    admin = SXTUser(dotenv_file='.env_loader_admin')
+    admin.authenticate()
+    assert admin.user_id == 'testuser_owner'
+
+    # get list of all users in subscription
+    success, users = admin.get_subscription_users()
+    assert success
+    for userid, role in users.items():
+        if userid == admin.user_id: continue # skip self
+
+        # remove all other users from subscription
+        success, response = admin.remove_from_subscription(userid)
+        assert success
+
+    success, users = admin.get_subscription_users()
+    assert len(users) == 1
+
+
+def test_adding_users_to_subscription():
+    # login with admin 
+    steve = SXTUser(dotenv_file='.env_loader_admin')
+    steve.authenticate()
+    assert steve.user_id == 'testuser_owner'
+
+    sxtloader_users = []
+
+    # create N new load users
+    for i in range(0,5):
+
+        # load keys, then override name
+        sxtloaderN = SXTUser(dotenv_file='.env_loader',
+                            user_id=f'testuser_joincode{i}_{str(random.randint(0,999999)).zfill(6)}',)
+        assert 'disconnected' in sxtloaderN.subscription_id
+        assert sxtloaderN.exists == False
+        
+        # register new user and add to subscription
+        joincode = steve.generate_joincode(role='member')
+        assert len(joincode) > 0
+
+        success, response = sxtloaderN.register_new_user() 
+        assert sxtloaderN.exists == True
+        assert sxtloaderN.subscription_id == ''
+        first_access_token = sxtloaderN.access_token
+
+        if success: success, response = sxtloaderN.join_subscription(joincode)
+        assert sxtloaderN.subscription_id != ''
+        assert 'disconnected' not in sxtloaderN.subscription_id
+        assert first_access_token != sxtloaderN.access_token
+
+        success, response = sxtloaderN.leave_subscription()
+        
+
+if __name__ == '__main__':
+    test_remove_all_users_from_test_subscription()
+    test_adding_users_to_subscription()
+    pass 

--- a/tests/test_sxtresource.py
+++ b/tests/test_sxtresource.py
@@ -64,7 +64,7 @@ def test_inserts_deletes_updates():
     sxt = SpaceAndTime()
     sxt.authenticate()
 
-    tbl = SXTTable(name='SXTTemp.Test_DML', from_file='./.env', SpaceAndTime_parent=sxt)
+    tbl = SXTTable(name='SXTTemp.Test_DML1', from_file='./.env', SpaceAndTime_parent=sxt)
     tbl.create_ddl = """
     CREATE TABLE {table_name} 
     ( MyID         int
@@ -77,14 +77,14 @@ def test_inserts_deletes_updates():
     if not tbl.exists: 
         tbl.create()
     else:
-        tbl.delete(where='')
+        tbl.delete(where='1=1')
 
-    data = [ {'MyID':1, 'MyName':'Abby',  'MyNumber':6}
+    data_in = [ {'MyID':1, 'MyName':'Abby',  'MyNumber':6}
             ,{'MyID':2, 'MyName':'Bob',   'MyNumber':6}
             ,{'MyID':3, 'MyName':'Chuck', 'MyNumber':6}
             ,{'MyID':4, 'MyName':'Daria', 'MyNumber':6}
             ]
-    tbl.insert.with_list_of_dicts(data)
+    tbl.insert.with_list_of_dicts(data_in)
     success, data = tbl.select()
     assert success
     assert [r['MYNUMBER'] for r in data] == [6, 6, 6, 6]


### PR DESCRIPTION
Per customer request, so they could better manage their subscription via Python:

- fixed a bug in consuming joincodes

Extended new properties (api call wrappers):
- User.Subscription_ID
- User.Is_Trial
- User.Is_Quota_Exceeded
- User.Is_Restricted

Extended new methods:
- User.Get_Subscription_Users (returns json list of users in current subscription)
- User.Leave_Subscription (allows user to leave their own current subscription
- User.Remove_Subscription (allows Admin to remove another user from their subscription)
